### PR TITLE
fix: correct getOptions to getOption typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ First, install the current version of the package from R-Universe:
 ``` r
 install.packages(
   "epiextractr", 
-  repos = c("https://economic.r-universe.dev", getOptions("repos"))
+  repos = c("https://economic.r-universe.dev", getOption("repos"))
 )
 ```
 


### PR DESCRIPTION
## Summary
Fix a typo in the README.md installation instructions: `getOptions()` → `getOption()` (singular).

## What was wrong
The R installation code example incorrectly used `getOptions("repos")` (plural) instead of the correct `getOption("repos")` (singular) function name.

## Fix
- `README.md` line 44: `getOptions("repos")` → `getOption("repos")`

## Verification
`getOption()` is the correct R base function for retrieving a single option value. The singular form is already used correctly on line 54 of the same file.

Fixes issue #25.