### PR TITLE
docs: fix getOption typo in install instructions

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -68,7 +68,7 @@ First, install the current version of the package from R-Universe:
 
 install.packages(
   "epiextractr", 
-  repos = c("https://economic.r-universe.dev", getOptions("repos"))
+  repos = c("https://economic.r-universe.dev", getOption("repos"))
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ First, install the current version of the package from R-Universe:
 ``` r
 install.packages(
   "epiextractr", 
-  repos = c("https://economic.r-universe.dev", getOptions("repos"))
+  repos = c("https://economic.r-universe.dev", getOption("repos"))
 )
 ```
 


### PR DESCRIPTION
## What & why

Fixes the installation instructions to use the R function `getOption()` instead of the non-existent `getOptions()`. Updated both `README.Rmd` and the generated `README.md`.

Closes #25.

## Verification

- `rg "getOptions"` returns no matches after the change.
- Docs-only change.
